### PR TITLE
Invoice upload by FTP (through Laravel api) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ $ curl "https://invoice-as-a-service.cleverapps.io/api/invoice/generate" \
 
         "s3": {
             "presigned_url": null
+        },
+
+        "ftp": {
+        	"host": "127.0.0.1",
+        	"username": "ftpuser",
+        	"password": "superSecretPassword",
+        	"path" : "/var/html/share/"
         }
 
      }'
@@ -106,6 +113,7 @@ $ curl "http://localhost:8000/api/invoice/generate" \
 | **customer** | object | yes | Customer infos | Customer(...) |
 | **company** | object | yes | Company infos | Company(...) |
 | **s3** | object | false | AWS S3 invoice upload | S3Upload(...) |
+| **FTP** | object | false | FTP invoice upload | FTPUpload(...) |
 
 ### Item:
 
@@ -159,6 +167,19 @@ $ curl "http://localhost:8000/api/invoice/generate" \
 | Property | Type | Required | Description | Example |
 | --- | --- | :---: | --- | --- |
 | **presigned_url** | string | false | Presigned AWS S3 upload url | "https://<span></span>my-bucket.s3.eu-central-1.amazonaws.com/201807250018--foobar@example.com.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=xxxx&X-Amz-Date=xxxx&X-Amz-Expires=xxxx&X-Amz-Signature=xxxx&X-Amz-SignedHeaders=host" |
+
+
+### FTP upload
+
+| Property | Type | Required | Description | Example |
+| --- | --- | :---: | --- | --- |
+| **host** | string | true | The host, IP Address of the server | "ftp.example.com" |
+| **username** | string | true | The ftp username to connect | "john" |
+| **password** | string | true | The ftp password of the user you are trying to connect | "test1234" |
+| **port** | integer | false | The port used to connect, default is 21. | 21 |
+| **ssl** | boolean | false | If the connection supports SSL mention that here, default is false. | true |
+| **passive** | boolean | false | If it should use a passive connection, default is true. | true |
+| **path** | string | true | The full path on the server where you want the invoice to be uploaded. | "/home/john/share" |
 
 
 ## Notes

--- a/app/Helpers/Storage.php
+++ b/app/Helpers/Storage.php
@@ -61,7 +61,7 @@ class Storage
      * @param  array $FTPcredentials The credentials for the FTP server
      * @return array                 Upload's result
      */
-    public function uploadFTP($FTPcredentials, $invoiceId) {
+    public function uploadFTP($FTPcredentials, $fileName) {
         if (ends_with($FTPcredentials["path"], "/") == false) {
             $FTPcredentials["path"] = $FTPcredentials["path"] . "/";
         }
@@ -89,9 +89,8 @@ class Storage
 
         $filesystem = new Filesystem($adapter);
 
-        $filePath = "invoice_". $invoiceId ."_" . time() .".pdf";
+        $response = $filesystem->write($fileName , $this->doc, ['visibility' => 'public']);
 
-        $response = $filesystem->write($filePath , $this->doc, ['visibility' => 'public']);
         if (!$response) {
             return [
                 'uploaded' => false,
@@ -103,9 +102,8 @@ class Storage
         return [
             'uploaded' => true,
             'message' => null,
-            'path' => $FTPcredentials["path"] . $filePath
+            'path' => $FTPcredentials["path"] . $fileName
         ];
-
 
     }
 

--- a/app/Helpers/Storage.php
+++ b/app/Helpers/Storage.php
@@ -5,6 +5,9 @@ namespace App\Helpers;
 use Log;
 use GuzzleHttp;
 
+use League\Flysystem\Filesystem;
+use League\Flysystem\Adapter\Ftp as Adapter;
+
 class Storage
 {
 
@@ -50,6 +53,66 @@ class Storage
             'uploaded' => true,
             'path' => preg_replace('/\?.*/', '', $presigned_url),
         ];
+    }
+
+
+    /**
+     * [uploadFTP description]
+     * @param  array $FTPcredentials The credentials for the FTP server
+     * @return array                 Upload's result
+     */
+    public function uploadFTP($FTPcredentials, $invoiceId) {
+        // TODO: check if path has trailing slash and add it automatically if its not there
+        // TODO: include ssl parameter and default it to false
+        // TODO: include passive parameter and default it to true
+        // TODO: make tests in case path does not exist (the ROOT param for the adapter)
+
+
+        if (ends_with($FTPcredentials["path"], "/") == false) {
+            $FTPcredentials["path"] = $FTPcredentials["path"] . "/";
+        }
+
+        $adapter = new Adapter([
+            'host' => $FTPcredentials["host"],
+            'username' => $FTPcredentials["username"],
+            'password' => $FTPcredentials["password"],
+            'port' => isset($FTPcredentials["port"]) ? $FTPcredentials["port"] : 21,
+            'root' => $FTPcredentials["path"],
+            'passive' => isset($FTPcredentials["passive"]) ? $FTPcredentials["passive"] : true,
+            'ssl' => isset($FTPcredentials["ssl"]) ? $FTPcredentials["ssl"] : false,
+            'timeout' => 300
+        ]);
+
+        try {
+            $adapter->getConnection();
+        } catch (\RuntimeException $e) {
+            return [
+                'uploaded' => false,
+                'message' => $e->getMessage(),
+                'path' => null,
+            ];
+        }
+
+        $filesystem = new Filesystem($adapter);
+
+        $filePath = "invoice_". $invoiceId ."_" . time() .".pdf";
+
+        $response = $filesystem->write($filePath , $this->doc, ['visibility' => 'public']);
+        if (!$response) {
+            return [
+                'uploaded' => false,
+                'message' => "The invoice could not be uploaded to the FTP server.",
+                'path' => null
+            ];
+        }
+
+        return [
+            'uploaded' => true,
+            'message' => null,
+            'path' => $FTPcredentials["path"] . $filePath
+        ];
+
+
     }
 
 }

--- a/app/Helpers/Storage.php
+++ b/app/Helpers/Storage.php
@@ -62,12 +62,6 @@ class Storage
      * @return array                 Upload's result
      */
     public function uploadFTP($FTPcredentials, $invoiceId) {
-        // TODO: check if path has trailing slash and add it automatically if its not there
-        // TODO: include ssl parameter and default it to false
-        // TODO: include passive parameter and default it to true
-        // TODO: make tests in case path does not exist (the ROOT param for the adapter)
-
-
         if (ends_with($FTPcredentials["path"], "/") == false) {
             $FTPcredentials["path"] = $FTPcredentials["path"] . "/";
         }

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -62,6 +62,14 @@ class InvoiceController extends Controller
 
             // optional
             's3.presigned_url' => 'nullable|string|active_url',
+
+            'ftp.host' => 'nullable|string',
+            'ftp.port' => 'nullable|integer',
+            'ftp.ssl' => 'nullable|boolean',
+            'ftp.passive' => 'nullable|boolean',
+            'ftp.username' => 'nullable|string|required_with:ftp.host',
+            'ftp.password' => 'nullable|string|required_with:ftp.host',
+            'ftp.path' => 'nullable|string|required_with:ftp.host'
         ]);
 
         if ($validator->fails())
@@ -108,6 +116,12 @@ class InvoiceController extends Controller
         );
 
         $doc = $pdf->build('default');
+
+        if (isset($data['ftp']) && isset($data['ftp']['host'])) {
+            $storage = new Storage($doc);
+            $res_body = $storage->uploadFTP($data['ftp'], $data['id']);
+            return response(['ftp' => $res_body], $res_body['uploaded'] == true ? 201 : 500);
+        }
 
         if (isset($data['s3']) && isset($data['s3']['presigned_url'])) {
             $storage = new Storage($doc);

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -117,17 +117,17 @@ class InvoiceController extends Controller
 
         $doc = $pdf->build('default');
 
-        if (isset($data['ftp']) && isset($data['ftp']['host'])) {
-            $storage = new Storage($doc);
-            $res_body = $storage->uploadFTP($data['ftp'], $data['id']);
-            return response(['ftp' => $res_body], $res_body['uploaded'] == true ? 201 : 500);
-        }
-
         if (isset($data['s3']) && isset($data['s3']['presigned_url'])) {
             $storage = new Storage($doc);
             $res_body = $storage->uploadS3($data['s3']['presigned_url']);
             return response(['s3' => $res_body], $res_body['uploaded'] == true ? 201 : 500);
-        } else {
+        }
+        else if (isset($data['ftp']) && isset($data['ftp']['host'])) {
+            $storage = new Storage($doc);
+            $res_body = $storage->uploadFTP($data['ftp'], $data['id']);
+            return response(['ftp' => $res_body], $res_body['uploaded'] == true ? 201 : 500);
+        }
+        else {
             return response($doc, 201);
         }
     }

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -117,18 +117,24 @@ class InvoiceController extends Controller
 
         $doc = $pdf->build('default');
 
+		$response = [];
+        $fileName = "invoice_". $data["id"] ."_" . time() .".pdf";
+
         if (isset($data['s3']) && isset($data['s3']['presigned_url'])) {
             $storage = new Storage($doc);
-            $res_body = $storage->uploadS3($data['s3']['presigned_url']);
-            return response(['s3' => $res_body], $res_body['uploaded'] == true ? 201 : 500);
+			$response['s3'] = $storage->uploadS3($data['s3']['presigned_url']);
         }
-        else if (isset($data['ftp']) && isset($data['ftp']['host'])) {
+
+		if (isset($data['ftp']) && isset($data['ftp']['host'])) {
             $storage = new Storage($doc);
-            $res_body = $storage->uploadFTP($data['ftp'], $data['id']);
-            return response(['ftp' => $res_body], $res_body['uploaded'] == true ? 201 : 500);
+            $response['ftp'] = $storage->uploadFTP($data['ftp'], $fileName);
         }
-        else {
+
+
+		if (!count($response)) {
             return response($doc, 201);
-        }
+        } else {
+			return response($response, 201);
+		}
     }
 }


### PR DESCRIPTION
FTP credentials and other settings are expected in the request.
S3 upload is on top of priorities for upload, before the FTP upload. Maybe this can be finetuned to accept both at the same time. 
This is related to issue #10 